### PR TITLE
feat: add docker compose for laravel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  laravel.test:
+    image: ghcr.io/laravelphp/sail-8.2/app
+    ports:
+      - '${APP_PORT:-8000}:80'
+    environment:
+      WWWUSER: '${WWWUSER:-1000}'
+      LARAVEL_SAIL: 1
+    volumes:
+      - '.:/var/www/html'
+    networks:
+      - sail
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mysql/mysql-server:8.0
+    ports:
+      - '${FORWARD_DB_PORT:-3306}:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD:-secret}'
+      MYSQL_DATABASE: '${DB_DATABASE:-laravel}'
+      MYSQL_USER: '${DB_USERNAME:-sail}'
+      MYSQL_PASSWORD: '${DB_PASSWORD:-secret}'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - 'sail-mysql:/var/lib/mysql'
+    networks:
+      - sail
+
+networks:
+  sail:
+    driver: bridge
+
+volumes:
+  sail-mysql:
+    driver: local


### PR DESCRIPTION
## Summary
- add docker-compose.yml for running Laravel with Sail and MySQL services

## Testing
- `composer install --no-interaction --no-progress` (fails: curl error 56 while downloading packages)
- `composer test` (fails: vendor/autoload.php missing)


------
https://chatgpt.com/codex/tasks/task_e_68b7d9111a68832bb67f56ef058c205b